### PR TITLE
Fix for https://ci-apps.yunohost.org/ci/job/17603

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     "multi_instance": true,
     "services": [
         "nginx",
-        "php7.3-fpm",
+        "php7.4-fpm",
         "mysql"
     ],
     "arguments": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="php$YNH_DEFAULT_PHP_VERSION-fpm php$YNH_DEFAULT_PHP_VERSION-mbstring"
+pkg_dependencies="php7.4-fpm php7.4-mbstring"
 app_dependencies="gemserv"
 
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,8 +4,10 @@
 # COMMON VARIABLES
 #=================================================
 
+YNH_PHP_VERSION="7.4"
+
 # dependencies used by the app
-pkg_dependencies="php7.4-fpm php7.4-mbstring"
+pkg_dependencies="php${YNH_PHP_VERSION}-fpm php${YNH_PHP_VERSION}-mbstring"
 app_dependencies="gemserv"
 
 #=================================================


### PR DESCRIPTION
## Problem

- linter warning : "Do not use YNH_DEFAULT_PHP_VERSION in _common.sh"

## Solution

- php version explicitely stated in scripts/_common.sh & manifest.json

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
